### PR TITLE
Allow N/A for fields

### DIFF
--- a/src/components/Grid/index.js
+++ b/src/components/Grid/index.js
@@ -104,17 +104,21 @@ const Grid = ({ data }) => (
               <Icon icon={faGithubAlt} />
               {github}
             </Link>
-            <Link
-              href={`https://twitter.com/${twitter.replace('@', '')}`}
-              target="_blank"
-            >
-              <Icon icon={faTwitter} />
-              {twitter}
-            </Link>
-            <Link href={linkedin} target="_blank">
-              <Icon icon={faLinkedinIn} />
-              LinkedIn
-            </Link>
+            {twitter && twitter !== 'N/A' && (
+              <Link
+                href={`https://twitter.com/${twitter.replace('@', '')}`}
+                target="_blank"
+              >
+                <Icon icon={faTwitter} />
+                {twitter}
+              </Link>
+            )}
+            {linkedin && linkedin !== 'N/A' && (
+              <Link href={linkedin} target="_blank">
+                <Icon icon={faLinkedinIn} />
+                LinkedIn
+              </Link>
+            )}
           </Content>
         </ContentContainer>
       </Card>


### PR DESCRIPTION
This hides the linkedIn & Twitter links if these are either non-existent or `N/A` (I left the github link since it's required anyways).
Fixes #9.